### PR TITLE
Potential deadlock in subscriber callback

### DIFF
--- a/lua/Subscriber.lua
+++ b/lua/Subscriber.lua
@@ -89,7 +89,9 @@ end
 
 function Subscriber:triggerCallbacks()
   local cbs
-  while self:hasMessage() do
+  local count = self:getMessageCount()
+  while count > 0 do
+    count=count-1
     local msg, header = self:read(0)
     if msg ~= nil then
       cbs = cbs or utils.getTableKeys(self.callbacks)   -- lazy isolation copy of callbacks


### PR DESCRIPTION
When entering the method triggerCallbacks in the Subscriber module, there is a potential deadlock.
If messages arrive at higher rate than they are processed by the callbacks, the loop will never exit.
The deadlock happens, if two subscriber have to be checked, but only one will be checked because of its fast incoming messages.

If only a finite amount of messages is considered, the deadlock will be avoided.